### PR TITLE
Don't autoscale on number of requests

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -23,7 +23,6 @@ automatic_scaling:
   max_idle_instances: automatic
   min_pending_latency: 0.030s
   max_pending_latency: automatic
-  max_concurrent_requests: 20
   target_cpu_utilization: 0.65
   min_instances: 3
   max_instances: 100


### PR DESCRIPTION
Related to https://github.com/ImagingDataCommons/IDC-WebApp/issues/307, it seems that the autoscaling is introducing a time lag on some requests.

According to [the app engine docs](https://cloud.google.com/appengine/docs/standard/python/how-instances-are-managed) we can autoscale on CPU and latency which may provide better performance.

After discussion with the OHIF team, @swederik suggested this change.